### PR TITLE
Fix concept detail member table heading error

### DIFF
--- a/snomed-interaction-components/views/conceptDetailsPlugin/tabs/members.hbs
+++ b/snomed-interaction-components/views/conceptDetailsPlugin/tabs/members.hbs
@@ -3,7 +3,7 @@
         <tr>
             <th><span data-i18n-id="i18n_term" class="i18n">{{i18n "i18n_term" "Term"}}</span></th>
             {{#if_eq containingTermOnly false}}
-                <th><span data-i18n-id="i18n_conceptId" class="i18n">{{i18n "i18n_preferred_term" "Preferred Term"}}</span></th>
+                <th><span data-i18n-id="i18n_preferred_term" class="i18n">{{i18n "i18n_preferred_term" "Preferred Term"}}</span></th>
             {{/if_eq}}
             <th><span data-i18n-id="i18n_conceptId" class="i18n">{{i18n "i18n_conceptId" "Concept Id"}}</span></th>
         </tr>


### PR DESCRIPTION
This fixes a minor bug in which the table heading incorrectly displays "Concept Id" when it should be "Preferred term" after switching languages with the flag menu option.