### PR TITLE
Update Languages_es.properties

### DIFF
--- a/i18n/Languages_es.properties
+++ b/i18n/Languages_es.properties
@@ -16,7 +16,7 @@ i18n_home2 = Seleccione una edición de SNOMED CT y una perspectiva del menú su
 i18n_go_browsing = Ir al Navegador
 i18n_international_editions = Ediciones Internacionales
 i18n_local_extensions = EEdiciones Locales
-i18n_home3 = Puede enviar sus comentarios haciendo clic en el botón de "Feedback" en la cabecera de esta página. Sus opiniones son esenciales para el funcionamiento de este servicio.<br><strong>** Está disponible la versión de julio de 2016 de la Edición Internacional (Inglés). La última versión en castellano es la de octubre de 2016.**</strong>
+i18n_home3 = Puede enviar sus comentarios haciendo clic en el botón de "Feedback" en la cabecera de esta página. Sus opiniones son esenciales para el funcionamiento de este servicio.
 i18n_home4 = Si deseara participar en el desarrollo, este código está disponible con una licencia de código abierto Apache v2. Puede visitar el repositorio de código  abierto en <a href="https://github.com/IHTSDO/snomed-interaction-components" target="_blank">IHTSDO GitHub account</a>
 i18n_home5 = La IHTSDO provee este navegador como una herramienta de referencia. La Organización ofrece otras herramientas a sus miembros para su utilización en entornos clínicos.
 i18n_home6 = <span class="btn-success"><em>Ediciones</em></span> permitirá la selección de contenido de SNOMED CT de la Edición Internacional o de otras extensiones, con fechas específicas.


### PR DESCRIPTION
Removed incorrect text from the Spanish translation of the home content, referring to the 2016 edition. It seems it was a temporary message that stayed in the i18n file.